### PR TITLE
docs: refine verify binaries wording

### DIFF
--- a/usage/verify-binaries.rst
+++ b/usage/verify-binaries.rst
@@ -1,26 +1,27 @@
 Verify Binaries (verify)
 ========================
 
-This feature allows to verify the authenticity of the included binaries.
-The signature verification is based on a public key encryption algorithm
-and requires the ``*.sig`` files that are shipped with the packages.
+Use the "verify" command to verify the authenticity of the included
+binaries. Signature verification is based on a public key encryption
+algorithm and requires the ``*.sig`` files shipped with the packages.
 
 .. figure:: ../images/thor-util-verify-thor.exe
    :alt: Verify thor.exe signature using THOR Util
 
    Verify thor.exe signature using THOR Util
 
-To verify the integrity of THOR Util, download the public key used for the
-verification on Nextrons Website: https://www.nextron-systems.com/pki/
-The public key can be then used with the following command to verify the integrity of ``thor-util``:
+To verify the integrity of THOR Util, download the public key from
+Nextron's website: https://www.nextron-systems.com/pki/
+You can then use the public key with the following commands to verify
+``thor-util``:
 
-on Windows:
+On Windows:
 
 .. code:: doscon
 
    C:\thor>openssl dgst -sha256 -verify codesign.pem -signature thor-util.exe.sig thor-util.exe
 
-on Linux:
+On Linux:
 
 .. code:: console
 


### PR DESCRIPTION
## Summary
- clarify the verify command description and signature requirements
- improve the public-key verification instructions
- documentation-only change

Testing: not run locally