### PR TITLE
docs: refine diagnostics wording

### DIFF
--- a/usage/diagnostics.rst
+++ b/usage/diagnostics.rst
@@ -4,12 +4,12 @@
 Diagnostics
 ===========
 
-If THOR does not behave like it should, e.g. using more resources than
-you expected, taking a prolonged time to finish a scan, or unexpectedly
-exits with a generic error, you can create a diagnostics pack for our
-support to help you troubleshoot the issue.
+If THOR does not behave as expected, for example if it uses more
+resources than expected, takes a long time to finish a scan, or exits
+unexpectedly with a generic error, you can create a diagnostics pack for
+Nextron Support.
 
-This can be done using THOR Util's diagnostics command.
+Create the diagnostics pack with THOR Util's diagnostics command.
 
 .. code:: doscon
  
@@ -25,50 +25,46 @@ This can be done using THOR Util's diagnostics command.
      --output string   File to write diagnostics pack to (default "[...]\diagnostics.zip")
      --run             Rerun last THOR scan with debug logging before collecting diagnostics pack
 
-By default the ``diagnostics.zip`` file is put in THOR's working
-directory. The location is printed on the commandline in the end
-of the data collection and can be changed using the ``--output`` flag.
+By default, THOR Util writes the ``diagnostics.zip`` file to THOR's
+working directory. The location is printed on the command line after data
+collection finishes and can be changed with the ``--output`` flag.
 
-Get diagnostics of a running THOR scan
---------------------------------------
+Get diagnostics for a running THOR scan
+---------------------------------------
 
-The preferred method of collecting THOR diagnostics is
-to run THOR Util's diagnostics command directly when
-the issue is occurring. This generally means if you
-suspect THOR is stuck during a scan, high memory or
-CPU usage by THOR, or anything else during its runtime.
+The preferred way to collect THOR diagnostics is to run THOR Util's
+diagnostics command while the issue is occurring. Use this method if you
+suspect that THOR is stuck during a scan, that THOR has high memory or
+CPU usage, or that another issue occurs during runtime.
 
 .. code:: doscon
 
    C:\thor>thor-util.exe diagnostics
 
-Get diagnostics of a finished THOR scan
----------------------------------------
+Get diagnostics for a finished THOR scan
+----------------------------------------
 
-If the THOR run is already finished or stopped unexpectedly,
-you can also use the diagnostics command above, with the
-biggest downside that only a reduced - and mostly not helpful -
-amount of information can be collected. In those cases, you
-should use the ``--run`` flag to rerun the last THOR scan.
-Using the ``--run`` flag is the preferred method if THOR
-is exiting unexpectedly/randomly.
+If the THOR run has already finished or stopped unexpectedly, you can
+also use the diagnostics command shown above. However, only a limited
+amount of diagnostic data can be collected after the scan has ended. In
+those cases, use the ``--run`` flag to rerun the last THOR scan. The
+``--run`` flag is the preferred method if THOR exits unexpectedly or
+intermittently.
 
 .. code:: doscon
 
    C:\thor>thor-util.exe diagnostics --run
 
-What data is being collected
-----------------------------
+What data is collected
+----------------------
 
-The below data is being collected by THOR Util's
-diagnostics function:
+THOR Util's diagnostics function collects the following data:
 
-- A log of THOR Utils diagnostics run itself
-- Go Profiles for CPU, Memory and Go routines, see: https://go.dev/blog/pprof
+- A log of the THOR Util diagnostics run
+- Go profiles for CPU, memory, and goroutines, see: https://go.dev/blog/pprof
 - THOR's running configuration parameters
-- A process list of all running processes on the machine. (this
-  helps tremendously identifying processes that might disturb
-  THOR, like an AV/EDR)
+- A process list of all running processes on the machine. This helps
+  identify processes that might interfere with THOR, such as an AV/EDR.
 - A process dump of the running THOR instance
 - The progress state of the running THOR instance
 - A dump of the THOR DB
@@ -77,10 +73,9 @@ diagnostics function:
 .. hint::
    Critical or personal information may be present in the THOR log, THOR DB dump,
    running process list, in the THOR process dump, and in the progress report
-   (working item details like path information). The profiles may allow insights
-   on what type of data is being scanned but does not contain any specific pieces
-   of data.
+   (working item details like path information). The profiles may indicate what
+   type of data is being scanned but do not contain specific pieces of data.
 
-The diagnostics pack is only used to debug the issues you are facing with
-THOR and will be deleted from our systems once the root cause of your issue
-was found.
+The diagnostics pack is only used to investigate the issue you are facing
+with THOR and will be deleted from our systems after the root cause has
+been identified.


### PR DESCRIPTION
## Summary
- clarify when and how to collect diagnostics for running and finished scans
- improve the collected-data descriptions and support-facing wording
- documentation-only change

Testing: not run locally